### PR TITLE
Obscure API key in error messages

### DIFF
--- a/.changeset/fuzzy-experts-hang.md
+++ b/.changeset/fuzzy-experts-hang.md
@@ -1,0 +1,5 @@
+---
+"@google/generative-ai": patch
+---
+
+Obscure API key in error messages

--- a/packages/main/src/methods/count-tokens.ts
+++ b/packages/main/src/methods/count-tokens.ts
@@ -16,14 +16,14 @@
  */
 
 import { CountTokensRequest, CountTokensResponse } from "../../types";
-import { Task, getUrl, makeRequest } from "../requests/request";
+import { RequestUrl, Task, makeRequest } from "../requests/request";
 
 export async function countTokens(
   apiKey: string,
   model: string,
   params: CountTokensRequest,
 ): Promise<CountTokensResponse> {
-  const url = getUrl(model, Task.COUNT_TOKENS, apiKey, false);
+  const url = new RequestUrl(model, Task.COUNT_TOKENS, apiKey, false);
   const response = await makeRequest(url, JSON.stringify({ ...params, model }));
   return response.json();
 }

--- a/packages/main/src/methods/embed-content.ts
+++ b/packages/main/src/methods/embed-content.ts
@@ -21,14 +21,14 @@ import {
   EmbedContentRequest,
   EmbedContentResponse,
 } from "../../types";
-import { Task, getUrl, makeRequest } from "../requests/request";
+import { RequestUrl, Task, makeRequest } from "../requests/request";
 
 export async function embedContent(
   apiKey: string,
   model: string,
   params: EmbedContentRequest,
 ): Promise<EmbedContentResponse> {
-  const url = getUrl(model, Task.EMBED_CONTENT, apiKey, false);
+  const url = new RequestUrl(model, Task.EMBED_CONTENT, apiKey, false);
   const response = await makeRequest(url, JSON.stringify(params));
   return response.json();
 }
@@ -38,7 +38,7 @@ export async function batchEmbedContents(
   model: string,
   params: BatchEmbedContentsRequest,
 ): Promise<BatchEmbedContentsResponse> {
-  const url = getUrl(model, Task.BATCH_EMBED_CONTENTS, apiKey, false);
+  const url = new RequestUrl(model, Task.BATCH_EMBED_CONTENTS, apiKey, false);
   const requestsWithModel: EmbedContentRequest[] = params.requests.map(
     (request) => {
       return { ...request, model: `models/${model}` };

--- a/packages/main/src/methods/generate-content.test.ts
+++ b/packages/main/src/methods/generate-content.test.ts
@@ -54,7 +54,7 @@ describe("generateContent()", () => {
     const result = await generateContent("key", "model", fakeRequestParams);
     expect(result.response.text()).to.include("Helena");
     expect(makeRequestStub).to.be.calledWith(
-      match.string,
+      match.instanceOf(request.RequestUrl),
       match((value) => {
         return value.includes("contents");
       }),
@@ -68,7 +68,10 @@ describe("generateContent()", () => {
     const result = await generateContent("key", "model", fakeRequestParams);
     expect(result.response.text()).to.include("Use Freshly Ground Coffee");
     expect(result.response.text()).to.include("30 minutes of brewing");
-    expect(makeRequestStub).to.be.calledWith(match.string, match.any);
+    expect(makeRequestStub).to.be.calledWith(
+      match.instanceOf(request.RequestUrl),
+      match.any,
+    );
   });
   it("citations", async () => {
     const mockResponse = getMockResponse("unary-success-citations.json");
@@ -80,7 +83,10 @@ describe("generateContent()", () => {
     expect(
       result.response.candidates[0].citationMetadata.citationSources.length,
     ).to.equal(1);
-    expect(makeRequestStub).to.be.calledWith(match.string, match.any);
+    expect(makeRequestStub).to.be.calledWith(
+      match.instanceOf(request.RequestUrl),
+      match.any,
+    );
   });
   it("blocked prompt", async () => {
     const mockResponse = getMockResponse(
@@ -91,7 +97,10 @@ describe("generateContent()", () => {
     );
     const result = await generateContent("key", "model", fakeRequestParams);
     expect(result.response.text).to.throw("SAFETY");
-    expect(makeRequestStub).to.be.calledWith(match.string, match.any);
+    expect(makeRequestStub).to.be.calledWith(
+      match.instanceOf(request.RequestUrl),
+      match.any,
+    );
   });
   it("finishReason safety", async () => {
     const mockResponse = getMockResponse(
@@ -102,7 +111,10 @@ describe("generateContent()", () => {
     );
     const result = await generateContent("key", "model", fakeRequestParams);
     expect(result.response.text).to.throw("SAFETY");
-    expect(makeRequestStub).to.be.calledWith(match.string, match.any);
+    expect(makeRequestStub).to.be.calledWith(
+      match.instanceOf(request.RequestUrl),
+      match.any,
+    );
   });
   it("empty content", async () => {
     const mockResponse = getMockResponse("unary-failure-empty-content.json");
@@ -111,7 +123,10 @@ describe("generateContent()", () => {
     );
     const result = await generateContent("key", "model", fakeRequestParams);
     expect(result.response.text()).to.equal("");
-    expect(makeRequestStub).to.be.calledWith(match.string, match.any);
+    expect(makeRequestStub).to.be.calledWith(
+      match.instanceOf(request.RequestUrl),
+      match.any,
+    );
   });
   it("unknown enum - should ignore", async () => {
     const mockResponse = getMockResponse("unary-unknown-enum.json");
@@ -120,7 +135,10 @@ describe("generateContent()", () => {
     );
     const result = await generateContent("key", "model", fakeRequestParams);
     expect(result.response.text()).to.include("30 minutes of brewing");
-    expect(makeRequestStub).to.be.calledWith(match.string, match.any);
+    expect(makeRequestStub).to.be.calledWith(
+      match.instanceOf(request.RequestUrl),
+      match.any,
+    );
   });
   it("image rejected (400)", async () => {
     const mockResponse = getMockResponse("unary-failure-image-rejected.json");

--- a/packages/main/src/methods/generate-content.ts
+++ b/packages/main/src/methods/generate-content.ts
@@ -21,7 +21,7 @@ import {
   GenerateContentResult,
   GenerateContentStreamResult,
 } from "../../types";
-import { Task, getUrl, makeRequest } from "../requests/request";
+import { RequestUrl, Task, makeRequest } from "../requests/request";
 import { addHelpers } from "../requests/response-helpers";
 import { processStream } from "../requests/stream-reader";
 
@@ -30,7 +30,7 @@ export async function generateContentStream(
   model: string,
   params: GenerateContentRequest,
 ): Promise<GenerateContentStreamResult> {
-  const url = getUrl(
+  const url = new RequestUrl(
     model,
     Task.STREAM_GENERATE_CONTENT,
     apiKey,
@@ -45,7 +45,12 @@ export async function generateContent(
   model: string,
   params: GenerateContentRequest,
 ): Promise<GenerateContentResult> {
-  const url = getUrl(model, Task.GENERATE_CONTENT, apiKey, /* stream */ false);
+  const url = new RequestUrl(
+    model,
+    Task.GENERATE_CONTENT,
+    apiKey,
+    /* stream */ false,
+  );
   const response = await makeRequest(url, JSON.stringify(params));
   const responseJson: GenerateContentResponse = await response.json();
   const enhancedResponse = addHelpers(responseJson);

--- a/packages/main/src/requests/request.test.ts
+++ b/packages/main/src/requests/request.test.ts
@@ -19,25 +19,52 @@ import { expect, use } from "chai";
 import { restore, stub } from "sinon";
 import * as sinonChai from "sinon-chai";
 import * as chaiAsPromised from "chai-as-promised";
-import { Task, getUrl, makeRequest } from "./request";
+import { RequestUrl, Task, makeRequest } from "./request";
 
 use(sinonChai);
 use(chaiAsPromised);
+
+const fakeRequestUrl = new RequestUrl(
+  "model-name",
+  Task.GENERATE_CONTENT,
+  "key",
+  true,
+);
 
 describe("request methods", () => {
   afterEach(() => {
     restore();
   });
-  describe("getUrl", () => {
+  describe("RequestUrl", () => {
     it("stream", async () => {
-      const url = getUrl("model-name", Task.GENERATE_CONTENT, "key", true);
-      expect(url).to.include("generateContent");
-      expect(url).to.include("alt=sse");
+      const url = new RequestUrl(
+        "model-name",
+        Task.GENERATE_CONTENT,
+        "key",
+        true,
+      );
+      expect(url.toString()).to.include("generateContent");
+      expect(url.toString()).to.include("alt=sse");
     });
     it("non-stream", async () => {
-      const url = getUrl("model-name", Task.GENERATE_CONTENT, "key", false);
-      expect(url).to.include("generateContent");
-      expect(url).to.not.include("alt=sse");
+      const url = new RequestUrl(
+        "model-name",
+        Task.GENERATE_CONTENT,
+        "key",
+        false,
+      );
+      expect(url.toString()).to.include("generateContent");
+      expect(url.toString()).to.include("key=key");
+      expect(url.toString()).to.not.include("alt=sse");
+    });
+    it("obscured", async () => {
+      const url = new RequestUrl(
+        "model-name",
+        Task.GENERATE_CONTENT,
+        "key",
+        false,
+      );
+      expect(url.toObscuredString()).to.include("key=__API_KEY__");
     });
   });
   describe("makeRequest", () => {
@@ -45,7 +72,7 @@ describe("request methods", () => {
       const fetchStub = stub(globalThis, "fetch").resolves({
         ok: true,
       } as Response);
-      const response = await makeRequest("url", "");
+      const response = await makeRequest(fakeRequestUrl, "");
       expect(fetchStub).to.be.calledOnce;
       expect(response.ok).to.be.true;
     });
@@ -55,8 +82,8 @@ describe("request methods", () => {
         status: 500,
         statusText: "Server Error",
       } as Response);
-      await expect(makeRequest("url", "")).to.be.rejectedWith(
-        "500 Server Error",
+      await expect(makeRequest(fakeRequestUrl, "")).to.be.rejectedWith(
+        /key=__API_KEY__.*500 Server Error/,
       );
       expect(fetchStub).to.be.calledOnce;
     });
@@ -67,8 +94,8 @@ describe("request methods", () => {
         statusText: "Server Error",
         json: () => Promise.resolve({ error: { message: "extra info" } }),
       } as Response);
-      await expect(makeRequest("url", "")).to.be.rejectedWith(
-        /500 Server Error.*extra info/,
+      await expect(makeRequest(fakeRequestUrl, "")).to.be.rejectedWith(
+        /key=__API_KEY__.*500 Server Error.*extra info/,
       );
       expect(fetchStub).to.be.calledOnce;
     });
@@ -91,7 +118,7 @@ describe("request methods", () => {
             },
           }),
       } as Response);
-      await expect(makeRequest("url", "")).to.be.rejectedWith(
+      await expect(makeRequest(fakeRequestUrl, "")).to.be.rejectedWith(
         /500 Server Error.*extra info.*generic::invalid_argument/,
       );
       expect(fetchStub).to.be.calledOnce;

--- a/packages/main/src/requests/request.ts
+++ b/packages/main/src/requests/request.ts
@@ -36,17 +36,25 @@ export enum Task {
   BATCH_EMBED_CONTENTS = "batchEmbedContents",
 }
 
-export function getUrl(
-  model: string,
-  task: Task,
-  apiKey: string,
-  stream: boolean,
-): string {
-  let url = `${BASE_URL}/${API_VERSION}/models/${model}:${task}?key=${apiKey}`;
-  if (stream) {
-    url += "&alt=sse";
+export class RequestUrl {
+  constructor(
+    public model: string,
+    public task: Task,
+    public apiKey: string,
+    public stream: boolean,
+  ) {}
+  toString(apiKeyInUrl = this.apiKey): string {
+    let url =
+      `${BASE_URL}/${API_VERSION}` +
+      `/models/${this.model}:${this.task}?key=${apiKeyInUrl}`;
+    if (this.stream) {
+      url += "&alt=sse";
+    }
+    return url;
   }
-  return url;
+  toObscuredString(): string {
+    return this.toString("__API_KEY__");
+  }
 }
 
 /**
@@ -57,12 +65,12 @@ function getClientHeaders(): string {
 }
 
 export async function makeRequest(
-  url: string,
+  url: RequestUrl,
   body: string,
 ): Promise<Response> {
   let response;
   try {
-    response = await fetch(url, {
+    response = await fetch(url.toString(), {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
@@ -85,7 +93,7 @@ export async function makeRequest(
     }
   } catch (e) {
     const err = new GoogleGenerativeAIError(
-      `Error fetching from ${url}: ${e.message}`,
+      `Error fetching from ${url.toObscuredString()}: ${e.message}`,
     );
     err.stack = e.stack;
     throw err;


### PR DESCRIPTION
Create a RequestUrl class that has fine grained access to url parts and can selectively obscure them.

Fixes https://github.com/google/generative-ai-js/issues/8