### PR TITLE
Fix a small typo in enums.ts

### DIFF
--- a/packages/main/types/enums.ts
+++ b/packages/main/types/enums.ts
@@ -28,7 +28,7 @@ export enum HarmCategory {
 }
 
 /**
- * Threshhold above which a prompt or candidate will be blocked.
+ * Threshold above which a prompt or candidate will be blocked.
  * @public
  */
 export enum HarmBlockThreshold {


### PR DESCRIPTION
Fixes a small typo in `packages/main/types/enum.ts`

`Threshhold` => `Threshold`

- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR
