### PR TITLE
Handle different model paths

### DIFF
--- a/.changeset/hip-pens-notice.md
+++ b/.changeset/hip-pens-notice.md
@@ -1,0 +1,5 @@
+---
+"@google/generative-ai": patch
+---
+
+Handle different model prefixes (such as tunedModels/).

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -53,4 +53,7 @@ jobs:
         run: yarn changeset publish
 
       - name: Git tags
-        run: git push --follow-tags
+        # list tags then try to push them
+        run: |
+          git for-each-ref refs/tags
+          git push --follow-tags

--- a/packages/main/src/gen-ai.test.ts
+++ b/packages/main/src/gen-ai.test.ts
@@ -29,6 +29,6 @@ describe("GoogleGenerativeAI", () => {
     const genAI = new GoogleGenerativeAI("apikey");
     const genModel = genAI.getGenerativeModel({ model: "my-model" });
     expect(genModel).to.be.an.instanceOf(GenerativeModel);
-    expect(genModel.model).to.equal("my-model");
+    expect(genModel.model).to.equal("models/my-model");
   });
 });

--- a/packages/main/src/methods/embed-content.ts
+++ b/packages/main/src/methods/embed-content.ts
@@ -48,7 +48,7 @@ export async function batchEmbedContents(
   const url = new RequestUrl(model, Task.BATCH_EMBED_CONTENTS, apiKey, false);
   const requestsWithModel: EmbedContentRequest[] = params.requests.map(
     (request) => {
-      return { ...request, model: `models/${model}` };
+      return { ...request, model };
     },
   );
   const response = await makeRequest(

--- a/packages/main/src/models/generative-model.test.ts
+++ b/packages/main/src/models/generative-model.test.ts
@@ -28,4 +28,10 @@ describe("GenerativeModel", () => {
     });
     expect(genModel.model).to.equal("models/my-model");
   });
+  it("handles prefixed tuned model name", () => {
+    const genModel = new GenerativeModel("apiKey", {
+      model: "tunedModels/my-model",
+    });
+    expect(genModel.model).to.equal("tunedModels/my-model");
+  });
 });

--- a/packages/main/src/models/generative-model.test.ts
+++ b/packages/main/src/models/generative-model.test.ts
@@ -20,12 +20,12 @@ import { GenerativeModel } from "./generative-model";
 describe("GenerativeModel", () => {
   it("handles plain model name", () => {
     const genModel = new GenerativeModel("apiKey", { model: "my-model" });
-    expect(genModel.model).to.equal("my-model");
+    expect(genModel.model).to.equal("models/my-model");
   });
   it("handles prefixed model name", () => {
     const genModel = new GenerativeModel("apiKey", {
       model: "models/my-model",
     });
-    expect(genModel.model).to.equal("my-model");
+    expect(genModel.model).to.equal("models/my-model");
   });
 });

--- a/packages/main/src/models/generative-model.ts
+++ b/packages/main/src/models/generative-model.ts
@@ -59,10 +59,12 @@ export class GenerativeModel {
     modelParams: ModelParams,
     requestOptions?: RequestOptions,
   ) {
-    if (modelParams.model.startsWith("models/")) {
-      this.model = modelParams.model.split("models/")?.[1];
-    } else {
+    if (modelParams.model.includes("/")) {
+      // Models may be named "models/model-name" or "tunedModels/model-name"
       this.model = modelParams.model;
+    } else {
+      // If path is not included, assume it's a non-tuned model.
+      this.model = `models/${modelParams.model}`;
     }
     this.generationConfig = modelParams.generationConfig || {};
     this.safetySettings = modelParams.safetySettings || [];

--- a/packages/main/src/requests/request.test.ts
+++ b/packages/main/src/requests/request.test.ts
@@ -38,23 +38,36 @@ describe("request methods", () => {
   describe("RequestUrl", () => {
     it("stream", async () => {
       const url = new RequestUrl(
-        "model-name",
+        "models/model-name",
         Task.GENERATE_CONTENT,
         "key",
         true,
       );
-      expect(url.toString()).to.include("generateContent");
+      expect(url.toString()).to.include("models/model-name:generateContent");
       expect(url.toString()).to.not.include("key");
       expect(url.toString()).to.include("alt=sse");
     });
     it("non-stream", async () => {
       const url = new RequestUrl(
-        "model-name",
+        "models/model-name",
         Task.GENERATE_CONTENT,
         "key",
         false,
       );
-      expect(url.toString()).to.include("generateContent");
+      expect(url.toString()).to.include("models/model-name:generateContent");
+      expect(url.toString()).to.not.include("key");
+      expect(url.toString()).to.not.include("alt=sse");
+    });
+    it("non-stream - tunedModels/", async () => {
+      const url = new RequestUrl(
+        "tunedModels/model-name",
+        Task.GENERATE_CONTENT,
+        "key",
+        false,
+      );
+      expect(url.toString()).to.include(
+        "tunedModels/model-name:generateContent",
+      );
       expect(url.toString()).to.not.include("key");
       expect(url.toString()).to.not.include("alt=sse");
     });

--- a/packages/main/src/requests/request.ts
+++ b/packages/main/src/requests/request.ts
@@ -45,7 +45,7 @@ export class RequestUrl {
     public stream: boolean,
   ) {}
   toString(): string {
-    let url = `${BASE_URL}/${API_VERSION}/models/${this.model}:${this.task}`;
+    let url = `${BASE_URL}/${API_VERSION}/${this.model}:${this.task}`;
     if (this.stream) {
       url += "?alt=sse";
     }

--- a/packages/main/test-integration/node/index.test.ts
+++ b/packages/main/test-integration/node/index.test.ts
@@ -247,11 +247,7 @@ describe("startChat", function () {
     const question1 = "What is the capital of Oregon?";
     const question2 = "How many people live there?";
     const question3 = "What is the closest river?";
-    const chat = model.startChat({
-      generationConfig: {
-        maxOutputTokens: 100,
-      },
-    });
+    const chat = model.startChat();
     const result1 = await chat.sendMessageStream(question1);
     const response1 = await result1.response;
     expect(response1.text()).to.not.be.empty;
@@ -287,11 +283,7 @@ describe("startChat", function () {
     const question1 = "What are the most interesting cities in Oregon?";
     const question2 = "How many people live there?";
     const question3 = "What is the closest river?";
-    const chat = model.startChat({
-      generationConfig: {
-        maxOutputTokens: 100,
-      },
-    });
+    const chat = model.startChat();
     const promise1 = chat.sendMessageStream(question1).then(async (result1) => {
       for await (const response of result1.stream) {
         expect(response.text()).to.not.be.empty;


### PR DESCRIPTION
Url paths to default models end with `/models/model-name` and the SDK is currently hardcoded to assume that (if no `models/` prefix is provided by the user in the constructor, we add it). We are introducing tuned models soon, which will end with `tunedModels/model-name`. Readjusting the parsing of model name so that:

- if the user provides`my-model`, we convert it to `models/my-model`
- if the user provides `models/my-model` we leave it alone
- if the user provides `tunedModels/my-tuned-model` we leave it alone

`GenerativeModel` now stores the full model path including the prefix and slash, and passes this to `RequestUrl`.