### PR TITLE
Add git config user/email to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,6 +49,11 @@ jobs:
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Set up user info for git committing
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
       - name: Publish
         run: yarn changeset publish
 


### PR DESCRIPTION
I think this was preventing the git tags from being published. Seems to fail silently when using the changesets CLI to publish but not using the changesets action: https://github.com/changesets/changesets/issues/972

Fixes https://github.com/google/generative-ai-js/issues/46