### PR TITLE
Fix requestOptions not being passed through countTokens and other methods

### DIFF
--- a/.changeset/green-apes-dress.md
+++ b/.changeset/green-apes-dress.md
@@ -1,0 +1,5 @@
+---
+"@google/generative-ai": patch
+---
+
+Fix requestOptions not being passed through countTokens, embedContent, and batchEmbedContents

--- a/packages/main/src/methods/count-tokens.ts
+++ b/packages/main/src/methods/count-tokens.ts
@@ -28,7 +28,13 @@ export async function countTokens(
   params: CountTokensRequest,
   requestOptions?: RequestOptions,
 ): Promise<CountTokensResponse> {
-  const url = new RequestUrl(model, Task.COUNT_TOKENS, apiKey, false, {});
+  const url = new RequestUrl(
+    model,
+    Task.COUNT_TOKENS,
+    apiKey,
+    false,
+    requestOptions,
+  );
   const response = await makeRequest(
     url,
     JSON.stringify({ ...params, model }),

--- a/packages/main/src/methods/embed-content.ts
+++ b/packages/main/src/methods/embed-content.ts
@@ -30,7 +30,13 @@ export async function embedContent(
   params: EmbedContentRequest,
   requestOptions?: RequestOptions,
 ): Promise<EmbedContentResponse> {
-  const url = new RequestUrl(model, Task.EMBED_CONTENT, apiKey, false, {});
+  const url = new RequestUrl(
+    model,
+    Task.EMBED_CONTENT,
+    apiKey,
+    false,
+    requestOptions,
+  );
   const response = await makeRequest(
     url,
     JSON.stringify(params),
@@ -50,7 +56,7 @@ export async function batchEmbedContents(
     Task.BATCH_EMBED_CONTENTS,
     apiKey,
     false,
-    {},
+    requestOptions,
   );
   const requestsWithModel: EmbedContentRequest[] = params.requests.map(
     (request) => {


### PR DESCRIPTION
Fixes #71 

RequestOptions (and therefore `apiVersion`) was not being passed through countTokens, embedContent, and batchEmbedContents.