### PR TITLE
Adds apiClient to requestOptions.

### DIFF
--- a/.changeset/dull-boats-cover.md
+++ b/.changeset/dull-boats-cover.md
@@ -1,0 +1,5 @@
+---
+"@google/generative-ai": minor
+---
+
+Adds `apiClient` configuration option to `RequestOptions`.

--- a/packages/main/src/requests/request.ts
+++ b/packages/main/src/requests/request.ts
@@ -58,8 +58,8 @@ export class RequestUrl {
 /**
  * Simple, but may become more complex if we add more versions to log.
  */
-function getClientHeaders(): string {
-  return `${PACKAGE_LOG_HEADER}/${PACKAGE_VERSION}`;
+function getClientHeaders(apiClient?: string): string {
+  return `${apiClient ? apiClient + ' ' : ''}${PACKAGE_LOG_HEADER}/${PACKAGE_VERSION}`;
 }
 
 export async function makeRequest(
@@ -74,7 +74,7 @@ export async function makeRequest(
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        "x-goog-api-client": getClientHeaders(),
+        "x-goog-api-client": getClientHeaders(requestOptions?.apiClient),
         "x-goog-api-key": url.apiKey,
       },
       body,

--- a/packages/main/src/requests/request.ts
+++ b/packages/main/src/requests/request.ts
@@ -59,7 +59,9 @@ export class RequestUrl {
  * Simple, but may become more complex if we add more versions to log.
  */
 function getClientHeaders(apiClient?: string): string {
-  return `${apiClient ? apiClient + ' ' : ''}${PACKAGE_LOG_HEADER}/${PACKAGE_VERSION}`;
+  return `${
+    apiClient ? apiClient + " " : ""
+  }${PACKAGE_LOG_HEADER}/${PACKAGE_VERSION}`;
 }
 
 export async function makeRequest(

--- a/packages/main/types/requests.ts
+++ b/packages/main/types/requests.ts
@@ -116,6 +116,11 @@ export interface RequestOptions {
    * defaults to latest stable version.
    */
   apiVersion?: string;
+  /**
+   * Additional attribution information to include in the x-goog-api-client header.
+   * Used by wrapper SDKs.
+   */
+  apiClient?: string;
 }
 /**
  * Defines a tool that model can call to access external knowledge.


### PR DESCRIPTION
- [x] Tests pass
- [x] Appropriate changes to documentation are included in the PR

This adds an `apiClient` option to `RequestOptions` that allows wrapper SDKs to provide additional information in the `X-Goog-Api-Client` header.