### PR TITLE
Change default apiVersion to "v1beta"

### DIFF
--- a/.changeset/few-crabs-crash.md
+++ b/.changeset/few-crabs-crash.md
@@ -2,4 +2,4 @@
 "@google/generative-ai": minor
 ---
 
-Set default API version to v1beta
+Set default API version to "v1beta" to match Go and Python.

--- a/.changeset/few-crabs-crash.md
+++ b/.changeset/few-crabs-crash.md
@@ -1,0 +1,5 @@
+---
+"@google/generative-ai": minor
+---
+
+Set default API version to v1beta

--- a/README.md
+++ b/README.md
@@ -92,6 +92,9 @@ https://ai.google.dev/docs
 
 Find reference docs for this SDK [here in the repo](/docs/reference/generative-ai.md).
 
+## Changelog
+- `@google/generative-ai` - [CHANGELOG.md](/main/packages/main/CHANGELOG.md)
+
 ## Contributing
 
 See [Contributing](/docs/contributing.md) for more information on contributing to the Google AI JavaScript SDK.

--- a/packages/main/src/requests/request.ts
+++ b/packages/main/src/requests/request.ts
@@ -20,7 +20,7 @@ import { GoogleGenerativeAIError } from "../errors";
 
 export const DEFAULT_BASE_URL = "https://generativelanguage.googleapis.com";
 
-export const DEFAULT_API_VERSION = "v1";
+export const DEFAULT_API_VERSION = "v1beta";
 
 /**
  * We can't `require` package.json if this runs on web. We will use rollup to


### PR DESCRIPTION
Setting the default apiVersion to "v1beta" matches the other GoogleAI server SDKs (Go and Python).

For web users, this will be slightly different from other client SDKs such as Swift and Kotlin, which default to "v1".